### PR TITLE
Version script not found

### DIFF
--- a/builddeb.sh
+++ b/builddeb.sh
@@ -181,7 +181,7 @@ fi
 #########################################################################################
 #  3.  Tar up the code and move up to directory parent.
 #########################################################################################
-  VERSION=$(./version.sh)
+  VERSION=$(scripts/version.sh)
   TARNAME=motion_$VERSION.orig.tar.gz
 
   tar --exclude=".*" -zcf $TARNAME *


### PR DESCRIPTION
Trying to build the deb file for Motion 4.3.0 on a Raspberry Pi 3B running the Sep-2019 version of Raspbian Buster. Script terminates indicating deb packages were built but this is not the case.

```
jack@pi3:~/build $ ./builddeb.sh 

Usage:    builddeb.sh name email <optional branch>
Name:     Name to use for deb package must not include spaces
Email:    Email address to use for deb package
Branch:   The git branch name of Motion to build (If none specified, uses master)
Install:  Install required packages
Arch:     Architecture


Using Username: AdhocBuild, User Email: AdhocBuild@nowhere.com, Git Branch: master, Install Pkgs: N, Arch: armv7l

All packages installed
Cloning into 'motion'...
remote: Enumerating objects: 28, done.
remote: Counting objects: 100% (28/28), done.
remote: Compressing objects: 100% (25/25), done.
remote: Total 6912 (delta 17), reused 6 (delta 2), pack-reused 6884
Receiving objects: 100% (6912/6912), 6.01 MiB | 3.56 MiB/s, done.
Resolving deltas: 100% (5164/5164), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
Cloning into 'motion-packaging'...
remote: Enumerating objects: 120, done.
remote: Total 120 (delta 0), reused 0 (delta 0), pack-reused 120
Receiving objects: 100% (120/120), 93.83 KiB | 1.23 MiB/s, done.
Resolving deltas: 100% (36/36), done.
./builddeb.sh: 184: ./builddeb.sh: ./version.sh: not found
Already on 'master'
Your branch is up to date with 'origin/master'.
Building package....
The deb packages and build logs have been created and placed into /home/jack/build
jack@pi3:~/build $ 
```